### PR TITLE
feat #5: 메뉴 수정, 단 건 상세조회, 목록 조회, 삭제 api 구현

### DIFF
--- a/src/main/java/com/sparta/gourmate/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/controller/MenuController.java
@@ -50,16 +50,22 @@ public class MenuController {
     }
 
     @GetMapping("/stores/{storeId}")
-    public ResponseEntity<Page<MenuResponseDto>> getMenuList(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                             @PathVariable UUID storeId,
+    public ResponseEntity<Page<MenuResponseDto>> getMenuList(@PathVariable UUID storeId,
                                                              @RequestParam String query,
                                                              @RequestParam(defaultValue = "1") int page,
                                                              @RequestParam(defaultValue = "10") int size,
                                                              @RequestParam(defaultValue = "createdAt") String sortBy,
                                                              @RequestParam(defaultValue = "false") boolean isAsc) {
-        User user = userDetails.getUser();
-        Page<MenuResponseDto> responseDtoPage = menuService.getMenuList(user, storeId, query, page-1, size, sortBy, isAsc);
+        Page<MenuResponseDto> responseDtoPage = menuService.getMenuList(storeId, query, page-1, size, sortBy, isAsc);
         return ResponseEntity.ok(responseDtoPage);
+    }
+
+    @DeleteMapping("/{menuId}")
+    public ResponseEntity<Void> deleteMenu(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                           @PathVariable UUID menuId) {
+        User user = userDetails.getUser();
+        menuService.deleteMenu(user, menuId);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/sparta/gourmate/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/controller/MenuController.java
@@ -49,11 +49,11 @@ public class MenuController {
         return ResponseEntity.ok(responseDto);
     }
 
-    @GetMapping("stores/{storeId}")
+    @GetMapping("/stores/{storeId}")
     public ResponseEntity<Page<MenuResponseDto>> getMenuList(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                              @PathVariable UUID storeId,
                                                              @RequestParam String query,
-                                                             @RequestParam int page,
+                                                             @RequestParam(defaultValue = "1") int page,
                                                              @RequestParam(defaultValue = "10") int size,
                                                              @RequestParam(defaultValue = "createdAt") String sortBy,
                                                              @RequestParam(defaultValue = "false") boolean isAsc) {

--- a/src/main/java/com/sparta/gourmate/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/controller/MenuController.java
@@ -2,33 +2,64 @@ package com.sparta.gourmate.domain.menu.controller;
 
 import com.sparta.gourmate.domain.menu.dto.MenuRequestDto;
 import com.sparta.gourmate.domain.menu.dto.MenuResponseDto;
+import com.sparta.gourmate.domain.menu.dto.MenuUpdateRequestDto;
 import com.sparta.gourmate.domain.menu.service.MenuService;
 import com.sparta.gourmate.domain.user.entity.User;
 import com.sparta.gourmate.global.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/menu")
 public class MenuController {
 
     private final MenuService menuService;
 
-    @PostMapping("/menu")
+    @PostMapping()
     public ResponseEntity<MenuResponseDto> createMenu(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                       @Valid @RequestBody MenuRequestDto requestDto) {
         User user = userDetails.getUser();
         MenuResponseDto responseDto = menuService.createMenu(user, requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
 
+    }
+
+    @PatchMapping("/{menuId}")
+    public ResponseEntity<MenuResponseDto> updateMenu(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                      @PathVariable UUID menuId,
+                                                      @Valid @RequestBody MenuUpdateRequestDto updateRequestDto) {
+        User user = userDetails.getUser();
+        MenuResponseDto responseDto = menuService.updateMenu(user, menuId, updateRequestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/{menuId}")
+    public ResponseEntity<MenuResponseDto> getMenu(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                   @PathVariable UUID menuId) {
+        User user = userDetails.getUser();
+        MenuResponseDto responseDto = menuService.getMenu(user, menuId);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("stores/{storeId}")
+    public ResponseEntity<Page<MenuResponseDto>> getMenuList(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                             @PathVariable UUID storeId,
+                                                             @RequestParam String query,
+                                                             @RequestParam int page,
+                                                             @RequestParam(defaultValue = "10") int size,
+                                                             @RequestParam(defaultValue = "createdAt") String sortBy,
+                                                             @RequestParam(defaultValue = "false") boolean isAsc) {
+        User user = userDetails.getUser();
+        Page<MenuResponseDto> responseDtoPage = menuService.getMenuList(user, storeId, query, page-1, size, sortBy, isAsc);
+        return ResponseEntity.ok(responseDtoPage);
     }
 
 }

--- a/src/main/java/com/sparta/gourmate/domain/menu/dto/MenuResponseDto.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/dto/MenuResponseDto.java
@@ -4,6 +4,7 @@ import com.sparta.gourmate.domain.menu.entity.Menu;
 import com.sparta.gourmate.domain.menu.entity.MenuStatusEnum;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
@@ -14,6 +15,8 @@ public class MenuResponseDto {
     private final String description;
     private final Integer price;
     private final MenuStatusEnum status;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
 
     public MenuResponseDto(Menu menu) {
         this.storeId = menu.getStore().getId();
@@ -22,6 +25,8 @@ public class MenuResponseDto {
         this.description = menu.getDescription();
         this.price = menu.getPrice();
         this.status = menu.getStatus();
+        this.createdAt = menu.getCreatedAt();
+        this.updatedAt = menu.getUpdatedAt();
     }
 
 }

--- a/src/main/java/com/sparta/gourmate/domain/menu/dto/MenuUpdateRequestDto.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/dto/MenuUpdateRequestDto.java
@@ -1,0 +1,23 @@
+package com.sparta.gourmate.domain.menu.dto;
+
+import com.sparta.gourmate.domain.menu.entity.MenuStatusEnum;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MenuUpdateRequestDto {
+
+    private String menuName;
+
+    private String description;
+
+    @Positive(message = "MENU_PRICE_INVALID")
+    private Integer price;
+
+    @NotNull(message = "MENU_STATUS_INVALID")
+    private MenuStatusEnum status;
+
+}

--- a/src/main/java/com/sparta/gourmate/domain/menu/entity/Menu.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/entity/Menu.java
@@ -8,7 +8,6 @@ import com.sparta.gourmate.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
 import org.springframework.util.StringUtils;
 
 import java.util.UUID;
@@ -16,7 +15,6 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor
-@SQLDelete(sql = "UPDATE p_menu SET is_deleted = true, deleted_at = CURRENT_TIMESTAMP, deleted_by = user_id WHERE id = ?")
 @Table(name = "p_menu")
 public class Menu extends BaseEntity {
     @Id

--- a/src/main/java/com/sparta/gourmate/domain/menu/entity/Menu.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/entity/Menu.java
@@ -1,10 +1,13 @@
 package com.sparta.gourmate.domain.menu.entity;
 
 import com.sparta.gourmate.domain.menu.dto.MenuRequestDto;
+import com.sparta.gourmate.domain.menu.dto.MenuUpdateRequestDto;
 import com.sparta.gourmate.domain.store.entity.Store;
+import com.sparta.gourmate.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 import java.util.UUID;
 
@@ -12,7 +15,7 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 @Table(name = "p_menu")
-public class Menu {
+public class Menu extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
@@ -39,7 +42,37 @@ public class Menu {
         this.price = requestDto.getPrice();
         this.status = requestDto.getStatus();
         this.store = store;
+    }
 
+    public void update(MenuUpdateRequestDto updateRequestDto) {
+        updateName(updateRequestDto.getMenuName());
+        updateDescription(updateRequestDto.getDescription());
+        updatePrice(updateRequestDto.getPrice());
+        updateStatus(updateRequestDto.getStatus());
+    }
+
+    private void updateStatus(MenuStatusEnum status) {
+        if (status != null) {
+            this.status = status;
+        }
+    }
+
+    private void updatePrice(Integer price) {
+        if (price != null) {
+            this.price = price;
+        }
+    }
+
+    private void updateDescription(String description) {
+        if (StringUtils.hasText(description)) {
+            this.description = description;
+        }
+    }
+
+    private void updateName(String menuName) {
+        if (StringUtils.hasText(menuName)) {
+            this.name = menuName;
+        }
     }
 
 }

--- a/src/main/java/com/sparta/gourmate/domain/menu/entity/Menu.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/entity/Menu.java
@@ -3,10 +3,12 @@ package com.sparta.gourmate.domain.menu.entity;
 import com.sparta.gourmate.domain.menu.dto.MenuRequestDto;
 import com.sparta.gourmate.domain.menu.dto.MenuUpdateRequestDto;
 import com.sparta.gourmate.domain.store.entity.Store;
+import com.sparta.gourmate.domain.user.entity.User;
 import com.sparta.gourmate.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 import org.springframework.util.StringUtils;
 
 import java.util.UUID;
@@ -14,6 +16,7 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor
+@SQLDelete(sql = "UPDATE p_menu SET is_deleted = true, deleted_at = CURRENT_TIMESTAMP, deleted_by = user_id WHERE id = ?")
 @Table(name = "p_menu")
 public class Menu extends BaseEntity {
     @Id
@@ -36,12 +39,17 @@ public class Menu extends BaseEntity {
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
 
-    public Menu(MenuRequestDto requestDto, Store store) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public Menu(MenuRequestDto requestDto, Store store, User user) {
         this.name = requestDto.getMenuName();
         this.description = requestDto.getDescription();
         this.price = requestDto.getPrice();
         this.status = requestDto.getStatus();
         this.store = store;
+        this.user = user;
     }
 
     public void update(MenuUpdateRequestDto updateRequestDto) {

--- a/src/main/java/com/sparta/gourmate/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/repository/MenuRepository.java
@@ -1,10 +1,14 @@
 package com.sparta.gourmate.domain.menu.repository;
 
 import com.sparta.gourmate.domain.menu.entity.Menu;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface MenuRepository extends JpaRepository<Menu, UUID> {
+    Page<Menu> findAllByStoreId(UUID storeId, Pageable validatedPageable);
+    Page<Menu> findAllByStoreIdAndNameContaining(UUID storeId, String query, Pageable validatedPageable);
 
 }

--- a/src/main/java/com/sparta/gourmate/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/repository/MenuRepository.java
@@ -5,11 +5,23 @@ import com.sparta.gourmate.domain.menu.entity.MenuStatusEnum;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface MenuRepository extends JpaRepository<Menu, UUID> {
-    Page<Menu> findAllByStoreIdAndStatusInAndIsDeletedFalse(UUID storeId,List<MenuStatusEnum> statusList, Pageable validatedPageable);
-    Page<Menu> findAllByStoreIdAndStatusInAndNameContainingAndIsDeletedFalse(UUID storeId, List<MenuStatusEnum> statusList, String query, Pageable validatedPageable);
+    @Query("select m from Menu m " +
+            "where m.store.id = :storeId " +
+            "and m.status in :statusList " +
+            "and m.isDeleted = false")
+    Page<Menu> findActiveMenuByStoreAndStatus(UUID storeId, List<MenuStatusEnum> statusList, Pageable pageable);
+
+    @Query("select m from Menu m " +
+            "where m.store.id = :storeId " +
+            "and m.status in :statusList " +
+            "and m.name LIKE :query " +
+            "and m.isDeleted = false")
+    Page<Menu> findActiveMenuByStoreAndStatusAndName(UUID storeId, List<MenuStatusEnum> statusList, String query, Pageable pageable);
+
 }

--- a/src/main/java/com/sparta/gourmate/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/repository/MenuRepository.java
@@ -1,14 +1,16 @@
 package com.sparta.gourmate.domain.menu.repository;
 
 import com.sparta.gourmate.domain.menu.entity.Menu;
+import com.sparta.gourmate.domain.menu.entity.MenuStatusEnum;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface MenuRepository extends JpaRepository<Menu, UUID> {
-    Page<Menu> findAllByStoreId(UUID storeId, Pageable validatedPageable);
-    Page<Menu> findAllByStoreIdAndNameContaining(UUID storeId, String query, Pageable validatedPageable);
+    Page<Menu> findAllByStoreIdAndStatusIn(UUID storeId,List<MenuStatusEnum> statusList, Pageable validatedPageable);
+    Page<Menu> findAllByStoreIdAndStatusInAndNameContaining(UUID storeId, List<MenuStatusEnum> statusList, String query, Pageable validatedPageable);
 
 }

--- a/src/main/java/com/sparta/gourmate/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/repository/MenuRepository.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.UUID;
 
 public interface MenuRepository extends JpaRepository<Menu, UUID> {
-    Page<Menu> findAllByStoreIdAndStatusIn(UUID storeId,List<MenuStatusEnum> statusList, Pageable validatedPageable);
-    Page<Menu> findAllByStoreIdAndStatusInAndNameContaining(UUID storeId, List<MenuStatusEnum> statusList, String query, Pageable validatedPageable);
-
+    Page<Menu> findAllByStoreIdAndStatusInAndIsDeletedFalse(UUID storeId,List<MenuStatusEnum> statusList, Pageable validatedPageable);
+    Page<Menu> findAllByStoreIdAndStatusInAndNameContainingAndIsDeletedFalse(UUID storeId, List<MenuStatusEnum> statusList, String query, Pageable validatedPageable);
 }

--- a/src/main/java/com/sparta/gourmate/domain/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/service/MenuService.java
@@ -4,6 +4,7 @@ import com.sparta.gourmate.domain.menu.dto.MenuRequestDto;
 import com.sparta.gourmate.domain.menu.dto.MenuResponseDto;
 import com.sparta.gourmate.domain.menu.dto.MenuUpdateRequestDto;
 import com.sparta.gourmate.domain.menu.entity.Menu;
+import com.sparta.gourmate.domain.menu.entity.MenuStatusEnum;
 import com.sparta.gourmate.domain.menu.repository.MenuRepository;
 import com.sparta.gourmate.domain.store.entity.Store;
 import com.sparta.gourmate.domain.store.repository.StoreRepository;
@@ -19,6 +20,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -59,11 +62,12 @@ public class MenuService {
         Store store = checkStore(storeId);
         checkUser(user, store);
         Pageable pageable = createPageableWithSorting(page, size, sortBy, isAsc);
+        List<MenuStatusEnum> statusList = Arrays.asList(MenuStatusEnum.AVAILABLE, MenuStatusEnum.OUT_OF_STOCK);
         Page<Menu> menuList;
         if (query != null && !query.isEmpty()) {
-            menuList = menuRepository.findAllByStoreIdAndNameContaining(storeId, query, pageable);
+            menuList = menuRepository.findAllByStoreIdAndStatusInAndNameContaining(storeId, statusList, query, pageable);
         } else {
-            menuList = menuRepository.findAllByStoreId(storeId, pageable);
+            menuList = menuRepository.findAllByStoreIdAndStatusIn(storeId, statusList, pageable);
         }
         return menuList.map(MenuResponseDto::new);
     }

--- a/src/main/java/com/sparta/gourmate/domain/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/service/MenuService.java
@@ -76,7 +76,7 @@ public class MenuService {
         Menu menu = checkMenu(menuId);
         checkUserByMenu(user, menu);
         checkRole(user);
-        menuRepository.deleteById(menu.getId());
+        menu.markAsDeleted(user);
     }
 
     private Pageable createPageableWithSorting(int page, int size, String sortBy, boolean isAsc) {

--- a/src/main/java/com/sparta/gourmate/domain/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/service/MenuService.java
@@ -44,7 +44,6 @@ public class MenuService {
     public MenuResponseDto updateMenu(User user, UUID menuId, MenuUpdateRequestDto updateRequestDto) {
         Menu menu = checkMenu(menuId);
         checkUserByMenu(user, menu);
-        checkRole(user);
         menu.update(updateRequestDto);
         return new MenuResponseDto(menu);
     }
@@ -74,7 +73,6 @@ public class MenuService {
     public void deleteMenu(User user, UUID menuId) {
         Menu menu = checkMenu(menuId);
         checkUserByMenu(user, menu);
-        checkRole(user);
         menu.markAsDeleted(user);
     }
 

--- a/src/main/java/com/sparta/gourmate/domain/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/service/MenuService.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MenuService {
 
     private final MenuRepository menuRepository;
@@ -40,7 +41,6 @@ public class MenuService {
         return new MenuResponseDto(menu);
     }
 
-    @Transactional
     public MenuResponseDto updateMenu(User user, UUID menuId, MenuUpdateRequestDto updateRequestDto) {
         Menu menu = checkMenu(menuId);
         checkUserByMenu(user, menu);
@@ -71,7 +71,6 @@ public class MenuService {
         return menuList.map(MenuResponseDto::new);
     }
 
-    @Transactional
     public void deleteMenu(User user, UUID menuId) {
         Menu menu = checkMenu(menuId);
         checkUserByMenu(user, menu);

--- a/src/main/java/com/sparta/gourmate/domain/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/service/MenuService.java
@@ -2,6 +2,7 @@ package com.sparta.gourmate.domain.menu.service;
 
 import com.sparta.gourmate.domain.menu.dto.MenuRequestDto;
 import com.sparta.gourmate.domain.menu.dto.MenuResponseDto;
+import com.sparta.gourmate.domain.menu.dto.MenuUpdateRequestDto;
 import com.sparta.gourmate.domain.menu.entity.Menu;
 import com.sparta.gourmate.domain.menu.repository.MenuRepository;
 import com.sparta.gourmate.domain.store.entity.Store;
@@ -11,12 +12,15 @@ import com.sparta.gourmate.domain.user.entity.UserRoleEnum;
 import com.sparta.gourmate.global.exception.CustomException;
 import com.sparta.gourmate.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 import java.util.UUID;
-
-import static com.sparta.gourmate.global.exception.ErrorCode.STORE_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -34,9 +38,53 @@ public class MenuService {
         return new MenuResponseDto(menu);
     }
 
+    @Transactional
+    public MenuResponseDto updateMenu(User user, UUID menuId, MenuUpdateRequestDto updateRequestDto) {
+        Menu menu = checkMenu(menuId);
+        checkUser(user, menu.getStore());
+        checkRole(user);
+        menu.update(updateRequestDto);
+        return new MenuResponseDto(menu);
+    }
+
+    @Transactional(readOnly = true)
+    public MenuResponseDto getMenu(User user, UUID menuId) {
+        Menu menu = checkMenu(menuId);
+        checkUser(user, menu.getStore());
+        return new MenuResponseDto(menu);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<MenuResponseDto> getMenuList(User user, UUID storeId, String query, int page, int size, String sortBy, boolean isAsc) {
+        Store store = checkStore(storeId);
+        checkUser(user, store);
+        Pageable pageable = createPageableWithSorting(page, size, sortBy, isAsc);
+        Page<Menu> menuList;
+        if (query != null && !query.isEmpty()) {
+            menuList = menuRepository.findAllByStoreIdAndNameContaining(storeId, query, pageable);
+        } else {
+            menuList = menuRepository.findAllByStoreId(storeId, pageable);
+        }
+        return menuList.map(MenuResponseDto::new);
+    }
+
+    private Pageable createPageableWithSorting(int page, int size, String sortBy, boolean isAsc) {
+        if (size != 10 && size != 30 && size != 50) {
+            size = 10;
+        }
+        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sort = Sort.by(direction, sortBy);
+        return PageRequest.of(page, size, sort);
+    }
+
+    private Menu checkMenu(UUID menuId) {
+        return menuRepository.findById(menuId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+    }
+
     private Store checkStore(UUID storeId) {
         return storeRepository.findById(storeId)
-                .orElseThrow(() -> new CustomException(STORE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
     }
 
     private void checkUser(User user, Store store) {

--- a/src/main/java/com/sparta/gourmate/domain/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/gourmate/domain/menu/service/MenuService.java
@@ -36,8 +36,7 @@ public class MenuService {
         Store store = checkStore(requestDto.getStoreId());
         checkUserByStore(user, store);
         checkRole(user);
-        Menu menu = new Menu(requestDto, store, user);
-        menuRepository.save(menu);
+        Menu menu = menuRepository.save(new Menu(requestDto, store, user));
         return new MenuResponseDto(menu);
     }
 
@@ -64,9 +63,10 @@ public class MenuService {
         List<MenuStatusEnum> statusList = Arrays.asList(MenuStatusEnum.AVAILABLE, MenuStatusEnum.OUT_OF_STOCK);
         Page<Menu> menuList;
         if (query != null && !query.isEmpty()) {
-            menuList = menuRepository.findAllByStoreIdAndStatusInAndNameContainingAndIsDeletedFalse(storeId, statusList, query, pageable);
+            String queryWithWildcard = "%" + query + "%";
+            menuList = menuRepository.findActiveMenuByStoreAndStatusAndName(storeId, statusList, queryWithWildcard, pageable);
         } else {
-            menuList = menuRepository.findAllByStoreIdAndStatusInAndIsDeletedFalse(storeId, statusList, pageable);
+            menuList = menuRepository.findActiveMenuByStoreAndStatus(storeId, statusList, pageable);
         }
         return menuList.map(MenuResponseDto::new);
     }

--- a/src/main/java/com/sparta/gourmate/global/common/BaseEntity.java
+++ b/src/main/java/com/sparta/gourmate/global/common/BaseEntity.java
@@ -1,5 +1,6 @@
 package com.sparta.gourmate.global.common;
 
+import com.sparta.gourmate.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
@@ -40,4 +41,11 @@ public abstract class BaseEntity {
     private LocalDateTime deletedAt;
 
     private Boolean isDeleted = false;
+
+    public void markAsDeleted(User user) {
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = user.getId();
+        this.isDeleted = true;
+    }
+
 }

--- a/src/main/java/com/sparta/gourmate/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/gourmate/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     STORE_NOT_EXISTS("가게Id가 존재하지 않습니다.", BAD_REQUEST),
     STORE_NOT_FOUND("가게가 존재하지 않습니다.", NOT_FOUND),
 
+    MENU_NOT_FOUND("메뉴가 존재하지 않습니다.", NOT_FOUND),
     MENU_NAME_EMPTY("메뉴 이름이 존재하지 않습니다.", BAD_REQUEST),
     MENU_PRICE_EMPTY("메뉴 가격이 존재하지 않습니다.", BAD_REQUEST),
     MENU_PRICE_INVALID("메뉴 가격이 유효하지 않습니다.", BAD_REQUEST),


### PR DESCRIPTION
## #️⃣연관된 이슈

#5 메뉴 수정, 단 건 상세조회, 목록 조회, 삭제 api 구현


## 📝작업 내용
- 메뉴 수정, 단 건 상세조회, 목록 조회, 삭제 api 구현
- 메뉴 수정, 단 건 상세조회, 삭제 api 의 경우 해당 작성자이고 OWNER 인 경우만 가능
- 메뉴 수정시 PATCH 메소드 사용하여 부분수정 처리
- 메뉴 목록 조회 시 필터링 처리
    - 페이징 size 가 10, 30, 50 이 아닐 경우 10으로 설정
    - 메뉴명으로 검색시 와일드카드 적용
    - 메뉴 상태 HIDDEN 인 데이터 제외 (AVAILABLE 과 OUT_OF_STOCK만 노출)
    - 삭제여부 TRUE 인 데이터 제외
- 메뉴 삭제 api soft delete 적용

### 스크린샷

<!-- 선택사항 -->

## 💬리뷰 요구사항

<!-- 선택사항 -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
